### PR TITLE
General Benchmarking

### DIFF
--- a/InfinityCrawler.sln
+++ b/InfinityCrawler.sln
@@ -21,9 +21,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{46BF0980
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "InfinityCrawler", "src\InfinityCrawler\InfinityCrawler.csproj", "{90361E0D-CB4C-4BCC-AAF2-70DAF87D5565}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InfinityCrawler.Tests", "tests\InfinityCrawler.Tests\InfinityCrawler.Tests.csproj", "{F30AF2A4-C53F-40FE-8083-6A82C0583255}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "InfinityCrawler.Tests", "tests\InfinityCrawler.Tests\InfinityCrawler.Tests.csproj", "{F30AF2A4-C53F-40FE-8083-6A82C0583255}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InfinityCrawler.Tests.TestSite", "tests\InfinityCrawler.Tests.TestSite\InfinityCrawler.Tests.TestSite.csproj", "{483B6FC9-98E7-4BD4-BA09-80DF504E31B2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "InfinityCrawler.Tests.TestSite", "tests\InfinityCrawler.Tests.TestSite\InfinityCrawler.Tests.TestSite.csproj", "{483B6FC9-98E7-4BD4-BA09-80DF504E31B2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InfinityCrawler.Tests.Benchmarks", "tests\InfinityCrawler.Tests.Benchmarks\InfinityCrawler.Tests.Benchmarks.csproj", "{F17C5CAC-DF32-434B-A4C5-21CBDDA86B97}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -43,6 +45,10 @@ Global
 		{483B6FC9-98E7-4BD4-BA09-80DF504E31B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{483B6FC9-98E7-4BD4-BA09-80DF504E31B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{483B6FC9-98E7-4BD4-BA09-80DF504E31B2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F17C5CAC-DF32-434B-A4C5-21CBDDA86B97}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F17C5CAC-DF32-434B-A4C5-21CBDDA86B97}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F17C5CAC-DF32-434B-A4C5-21CBDDA86B97}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F17C5CAC-DF32-434B-A4C5-21CBDDA86B97}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -51,6 +57,7 @@ Global
 		{90361E0D-CB4C-4BCC-AAF2-70DAF87D5565} = {C6187826-9F4B-4E85-90D1-BC46A0F7F8F1}
 		{F30AF2A4-C53F-40FE-8083-6A82C0583255} = {46BF0980-A8A4-492E-8652-0725ADB6A683}
 		{483B6FC9-98E7-4BD4-BA09-80DF504E31B2} = {46BF0980-A8A4-492E-8652-0725ADB6A683}
+		{F17C5CAC-DF32-434B-A4C5-21CBDDA86B97} = {46BF0980-A8A4-492E-8652-0725ADB6A683}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FC9AB8BE-670B-4F26-9F17-73D2C0DECA6A}

--- a/tests/InfinityCrawler.Tests.Benchmarks/BasicSiteCrawlBenchmark.cs
+++ b/tests/InfinityCrawler.Tests.Benchmarks/BasicSiteCrawlBenchmark.cs
@@ -28,6 +28,12 @@ namespace InfinityCrawler.Tests.Benchmarks
 			Crawler = new Crawler(client, new ParallelAsyncTaskHandler());
 		}
 
+		[GlobalSetup]
+		public async Task Setup()
+		{
+			await CrawlSite(); // benchmark warmup as a workaround for https://github.com/dotnet/BenchmarkDotNet/issues/837
+		}
+
 		[Benchmark]
 		public async Task CrawlSite()
 		{

--- a/tests/InfinityCrawler.Tests.Benchmarks/BasicSiteCrawlBenchmark.cs
+++ b/tests/InfinityCrawler.Tests.Benchmarks/BasicSiteCrawlBenchmark.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using InfinityCrawler.TaskHandlers;
+using InfinityCrawler.Tests.TestSite;
+
+namespace InfinityCrawler.Tests.Benchmarks
+{
+	[CoreJob, ClrJob(baseline: true)]
+	[MemoryDiagnoser]
+	public class BasicSiteCrawlBenchmark
+	{
+		private TestSiteManager TestSite { get; }
+		private Crawler Crawler { get; }
+		private Uri Uri { get; } = new Uri("http://localhost/");
+
+		public BasicSiteCrawlBenchmark()
+		{
+			TestSite = new TestSiteManager(new SiteContext
+			{
+				SiteFolder = "BasicSite"
+			});
+
+			var client = TestSite.GetHttpClient();
+			Crawler = new Crawler(client, new ParallelAsyncTaskHandler());
+		}
+
+		[Benchmark]
+		public async Task CrawlSite()
+		{
+			var result = await Crawler.Crawl(Uri, new CrawlSettings
+			{
+				TaskHandlerOptions = new TaskHandlerOptions
+				{
+					MaxNumberOfSimultaneousTasks = 5,
+					DelayBetweenTaskStart = new TimeSpan(),
+					DelayJitter = new TimeSpan(),
+					TimeoutBeforeThrottle = new TimeSpan()
+				}
+			});
+		}
+	}
+}

--- a/tests/InfinityCrawler.Tests.Benchmarks/InfinityCrawler.Tests.Benchmarks.csproj
+++ b/tests/InfinityCrawler.Tests.Benchmarks/InfinityCrawler.Tests.Benchmarks.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\InfinityCrawler\InfinityCrawler.csproj" />
+    <ProjectReference Include="..\InfinityCrawler.Tests.TestSite\InfinityCrawler.Tests.TestSite.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/InfinityCrawler.Tests.Benchmarks/Program.cs
+++ b/tests/InfinityCrawler.Tests.Benchmarks/Program.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using BenchmarkDotNet.Running;
+
+namespace InfinityCrawler.Tests.Benchmarks
+{
+	class Program
+	{
+		static void Main(string[] args)
+		{
+			BenchmarkRunner.Run<BasicSiteCrawlBenchmark>();
+		}
+	}
+}


### PR DESCRIPTION
Basic Site Crawl - Initial Benchmark

``` ini

BenchmarkDotNet=v0.11.3, OS=Windows 10.0.17134.472 (1803/April2018Update/Redstone4)
Intel Core i7-6700HQ CPU 2.60GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
Frequency=2531251 Hz, Resolution=395.0616 ns, Timer=TSC
.NET Core SDK=2.1.502
  [Host] : .NET Core 2.1.6 (CoreCLR 4.6.27019.06, CoreFX 4.6.27019.05), 64bit RyuJIT  [AttachedDebugger]
  Clr    : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3260.0
  Core   : .NET Core 2.1.6 (CoreCLR 4.6.27019.06, CoreFX 4.6.27019.05), 64bit RyuJIT


```
|    Method |  Job | Runtime |     Mean |     Error |    StdDev | Ratio | RatioSD | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|---------- |----- |-------- |---------:|----------:|----------:|------:|--------:|------------:|------------:|------------:|--------------------:|
| CrawlSite |  Clr |     Clr | 2.028 ms | 0.0404 ms | 0.0879 ms |  1.00 |    0.00 |    234.3750 |           - |           - |           723.19 KB |
| CrawlSite | Core |    Core | 2.924 ms | 0.0558 ms | 0.0548 ms |  1.42 |    0.06 |    183.5938 |           - |           - |             7.07 KB |
